### PR TITLE
Docker build :repo name lower case

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,4 +28,4 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/DeepINN:pre-release
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/deepinn:pre-release


### PR DESCRIPTION
Otherwise you will get this error.
```sh
buildx failed with: ERROR: invalid tag "***/DeepINN:pre-release": repository name must be lowercase
```