### PR TITLE
removed shell from docker recipe

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,5 +6,4 @@ COPY ../DeepINN /workspace/
 WORKDIR /workspace
 RUN pip3 install -r requirements.txt 
 EXPOSE 8888/tcp
-ENV SHELL /bin/bash
-ENTRYPOINT ["jupyter", "notebook", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]
+ENTRYPOINT ["jupyter-lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]


### PR DESCRIPTION
trying to fix this error.

```sh
╰─ docker run -p 8888:8888 prakhars962/deepinn:pre-release 
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "jupyter": executable file not found in $PATH: unknown.
ERRO[0000] error waiting for container:  
```